### PR TITLE
Fix SugarSS Editing Error

### DIFF
--- a/syntax/sugarss.vim
+++ b/syntax/sugarss.vim
@@ -34,10 +34,6 @@ hi link  sssID Identifier
 sy match sssSelector /\(@\)\a\+/
 hi link  sssSelector Keyword
 
-'hell'
-"hell"
-'hell-o'
-
 " Property
 sy match sssProperty /(\@!\S*\(\:\s\)\@=/
 sy match sssPropertyOverride /\:/


### PR DESCRIPTION
# Why
- There was some test code in the syntax file that was causing an error
  when a user began editing a SugarSS file.
# This change addresses the need by
- Removing the offending test code.
- Issue #1 
